### PR TITLE
turn on noImplicitAny

### DIFF
--- a/spec/enterZone.spec.ts
+++ b/spec/enterZone.spec.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 
 import '../src/add/operator/enterZone';
 
-declare var Zone;
+declare var Zone: any;
 
 describe('enterZone Operator', function() {
   it('should cause an observable stream to enter the ng zone', function(done) {

--- a/spec/leaveZone.spec.ts
+++ b/spec/leaveZone.spec.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 
 import '../src/add/operator/leaveZone';
 
-declare var Zone;
+declare var Zone: any;
 
 describe('leaveZone Operator', function() {
   it('should cause an observable stream to leave the ng zone', function(done) {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -9,8 +9,8 @@ export interface ComposeSignature {
 }
 
 
-export const compose: ComposeSignature = (...functions) => {
-  return function(arg) {
+export const compose: ComposeSignature = (...functions: Function[]) => {
+  return function(arg: any) {
     if (functions.length === 0) {
       return arg;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,
+    "noImplicitAny": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",


### PR DESCRIPTION
Since this module is designed to be compiled by consumer projects (from what I can tell - see #15), it's nice to turn on `noImplicitAny` so those using `noImplicitAny` don't suffer compiler warnings.

The compose function had a signature, but `tsc` didn't seem to be able to infer its argument types so considers them implicitly any. I've added annotations, and checked that `ComposeSignature` is still the type consumers see.

I'm now using this commit in my project, and the compiler warnings have thankfully ceased 🎉

Fixes #15.