### PR TITLE
fix(type): reverse the overload sequence of ComposeSignature

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,10 +1,10 @@
 export interface ComposeSignature {
-  <A>(): (i: A) => A;
-  <A, B>(b: (i: A) => B): (i: A) => B;
-  <A, B, C>(c: (i: B) => C, b: (i: A) => B): (i: A) => C;
-  <A, B, C, D>(d: (i: C) => D, c: (i: B) => C, b: (i: A) => B): (i: A) => D;
-  <A, B, C, D, E>(e: (i: D) => E, d: (i: C) => D, c: (i: B) => C, b: (i: A) => B): (i: A) => E;
   <A, B, C, D, E, F>(f: (i: E) => F, e: (i: D) => E, d: (i: C) => D, c: (i: B) => C, b: (i: A) => B): (i: A) => F;
+  <A, B, C, D, E>(e: (i: D) => E, d: (i: C) => D, c: (i: B) => C, b: (i: A) => B): (i: A) => E;
+  <A, B, C, D>(d: (i: C) => D, c: (i: B) => C, b: (i: A) => B): (i: A) => D;
+  <A, B, C>(c: (i: B) => C, b: (i: A) => B): (i: A) => C;
+  <A, B>(b: (i: A) => B): (i: A) => B;
+  <A>(): (i: A) => A;
   (...fns: any[]): (input: any) => any;
 }
 


### PR DESCRIPTION
Without this fix, it will get typescript compiler error with typescript
v2.4.1 when `compose` has more than three args passed in.

As in https://www.typescriptlang.org/docs/handbook/functions.html, the
office example also places the signature with most args at the front.

Here we follow the example and make compiler find the best match.